### PR TITLE
Restrict to PR body only. Remove need for token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An action to validate that PR's contain a link to a change request. Originally d
 # Usage
 
 Add a new workflow in your repo that runs this action. Here's an example:
+
 ```yml
 name: Require PR links to change request
 
@@ -14,7 +15,7 @@ name: Require PR links to change request
 on:
   # Triggers the workflow on pull request events but only for the main branch
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -22,7 +23,7 @@ jobs:
   check-pr:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    
+
     # You may want to ignore some users like dependabot
     if: github.actor != 'dependabot[bot]'
 
@@ -30,25 +31,21 @@ jobs:
     steps:
       - name: Confirm link to change request included in PR
         uses: aminohealth/pr-check-action@master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Parameters
 
 ### Inputs
-* `repo-token`: Your GITHUB_TOKEN secret
-  * required: true
-* `link-regex`: A regex that matches your expected change request urls
-  * default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io))'
-* `success-message`: The message set on success
-  * default: "Found a change request link"
-* `failure-message`: The message set on failure
-  * default: "Unable to find a change request link matching {link-regex}"
-* `include-comments`: If true, include PR comments when looking for the change request
-  * default: false
-* `debug`: If true, prints debug info while running
-  * default: false
+
+- `link-regex`: A regex that matches your expected change request urls
+  - default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io))'
+- `success-message`: The message set on success
+  - default: "Found a change request link"
+- `failure-message`: The message set on failure
+  - default: "Unable to find a change request link matching {link-regex}"
+- `debug`: If true, prints debug info while running
+  - default: false
 
 ### Outputs
-*  `msg`: Will be set to the value of `success-message` if the action is successful
+
+- `msg`: Will be set to the value of `success-message` if the action is successful

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,6 @@
 name: "Confirm change request link included on Pull Request"
 description: "Confirm change request link included on Pull Request"
 inputs:
-  repo-token:
-    required: true
-    description: "GITHUB_TOKEN secret"
   link-regex:
     description: "Change request url regex"
     default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io))'
@@ -13,9 +10,6 @@ inputs:
   failure-message:
     description: "Message set on failure"
     default: "Unable to find a change request link matching {link-regex}"
-  include-comments:
-    description: "If true, include PR comments when looking for change request"
-    default: false
   debug:
     description: "If true, prints debug info workflow"
     default: false

--- a/index.js
+++ b/index.js
@@ -9,56 +9,27 @@ async function run() {
     // These inputs are always strings
     const isDebug = core.getInput("debug").toLowerCase() === "true";
 
-    //matching in pr comments OR body of pr
-    let matchedStrings = [];
-
     core.info(`Checking for links matching: ${linkRegExInput}!`);
 
-    const token = core.getInput("repo-token");
-    const octokit = new github.GitHub(token);
+    // Get the PR body from the payload
     const payload = github.context.payload;
+    isDebug && console.log("Payload:", payload);
 
-    // personal repos have no org - allow for those as well as team ones
-    const owner = (payload.organization || payload.repository.owner).login;
-    const repo = payload.repository.name;
-
-    // issue events (like create comment) supply #issue instead of #pull_request - handle both
-    const issue_number = (payload.pull_request || payload.issue).number;
-
-    const issuesArgs = { owner, repo, issue_number };
-
-    const pull = await octokit.issues.get(issuesArgs);
-    isDebug && console.log(`PR Body: \n${pull.data.body}\n`);
-
-    const bodyMatches = linkRegExp.exec(pull.data.body);
-    if (bodyMatches) {
-      matchedStrings.push(bodyMatches[0]);
+    if (!(payload && payload.pull_request)) {
+      core.setFailed(
+        "The payload doesn't appear to be a pull request. Make sure you're only running this action on pull_request."
+      );
     }
 
-    const includeComments =
-      core.getInput("include-comments").toLowerCase() === "true";
-    if (includeComments && matchedStrings.length < 1) {
-      const prComments = await octokit.issues.listComments(issuesArgs);
+    const body = payload.pull_request.body || "";
+    isDebug && console.log(`PR Body: \n${body}\n`);
 
-      const commentsWithLinks = prComments.data.reduce((acc, curr) => {
-        const matches = linkRegExp.exec(curr.body);
-        if (matches) acc.push(matches[0]);
-        return acc;
-      }, []);
+    const matchFound = linkRegExp.test(body);
 
-      matchedStrings = matchedStrings.concat(commentsWithLinks);
-
-      isDebug && console.log("PR Comments:\n");
-      isDebug && console.log(prComments.data.map((i) => i.body));
-    }
-
-    isDebug && console.log("matches:");
-    isDebug && console.log(matchedStrings);
-
-    const successMessage = core.getInput("success-message");
-    core.setOutput("msg", successMessage);
-
-    if (matchedStrings.length === 0) {
+    if (matchFound) {
+      const successMessage = core.getInput("success-message");
+      core.setOutput("msg", successMessage);
+    } else {
       const failureMessage = core
         .getInput("failure-message")
         .replace("{link-regex}", linkRegExInput);


### PR DESCRIPTION
This PR removes the option to inspect PR comments for change request links. This allows us to not require the `GITHUB_TOKEN`, as we're just looking at the body of the PR that's included in the payload.