### PR TITLE
Add linear.app to link-regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
 ### Inputs
 
 - `link-regex`: A regex that matches your expected change request urls
-  - default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io))'
+  - default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io|linear\.app))'
 - `success-message`: The message set on success
   - default: "Found a change request link"
 - `failure-message`: The message set on failure

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Confirm change request link included on Pull Request"
 inputs:
   link-regex:
     description: "Change request url regex"
-    default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io))'
+    default: '(https:\/\/(?:www.)?(?:pivotaltracker\.com|sentry\.io|linear\.app))'
   success-message:
     description: "Message set on success"
     default: "Found a change request link"


### PR DESCRIPTION
Linear issue: https://linear.app/amino/issue/SOL-97/add-linearapp-to-pr-check-action-regex-in-pare-web

Add the `linear.app` domain to the regex of approved URLs that can be used to document change requests.